### PR TITLE
update to support build asserts in aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           path: |
             src/*.tar.*
             src/*.zip
-          key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
+          key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.8
@@ -62,7 +62,7 @@ jobs:
           path: |
             src/*.tar.*
             src/*.zip
-          key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
+          key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.8
@@ -76,7 +76,7 @@ jobs:
           brew install automake
           brew install coreutils
           brew install gnu-getopt
-  
+
       - name: download
         if: steps.cache-source.outputs.cache-hit != 'true'
         run: |
@@ -113,7 +113,7 @@ jobs:
           path: |
             src/*.tar.*
             src/*.zip
-          key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
+          key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.8
@@ -147,13 +147,13 @@ jobs:
           path: |
             src/*.tar.*
             src/*.zip
-          key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
+          key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
           cmake-version: '3.20.x'
-      
+
       - name: Install System Dependencies
       # coreutils for nproc
         run: |
@@ -190,7 +190,7 @@ jobs:
           path: |
             src/*.tar.*
             src/*.zip
-          key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
+          key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
 
       - name: download
         if: steps.cache-source.outputs.cache-hit != 'true'
@@ -219,8 +219,8 @@ jobs:
           path: |
             src/*.tar.*
             src/*.zip
-          key: ${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
-      
+          key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
+
       - name: Install System Dependencies
       # coreutils for nproc
         run: |
@@ -241,11 +241,11 @@ jobs:
         with:
           name: artifact-mac
           path: boost-*.tar.gz
-          
+
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: ['build-other', 'build-llvm', 'build-boost', 
+    needs: ['build-other', 'build-llvm', 'build-boost',
     'build-other-mac', 'build-llvm-mac', 'build-boost-mac']
     steps:
       - uses: actions/checkout@v2
@@ -254,38 +254,30 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: artifact
-          path: linux/artifact
+          path: linux/
 
       - name: Download Artifacts For Mac
         uses: actions/download-artifact@v2
         with:
           name: artifact-mac
-          path: mac/artifact
+          path: darwin/
 
-      - name: Determine Version
+      - name: Pack All Linux
         run: |
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-      - name: Pack All
-        working-directory: linux
-        run: |
-          cp ../pack_all.sh .
-          ./pack_all.sh
+          ./pack_all.sh linux
 
       - name: Pack All For Mac
-        working-directory: mac
-        # rename the mac pkg
         run: |
-          cp ../pack_all.sh .
-          ./pack_all.sh
-          for var in artifact/thirdparty*.tar.gz; do mv "$var" "${var%.tar.gz}-darwin.tar.gz"; done
+          ./pack_all.sh darwin
+        env:
+          OS: darwin
+          ARCH: x86_64
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            linux/artifact/third*.tar.gz
-            mac/artifact/thirdparty*-darwin.tar.gz
+            linux/third*.tar.gz
+            darwin/thirdparty-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build-other:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/aceforeverd/hybridsql-base:0.0.8
+      image: ghcr.io/aceforeverd/hybridsql-base:0.4.0
 
     steps:
       - uses: actions/checkout@v2
@@ -26,11 +26,6 @@ jobs:
             src/*.tar.*
             src/*.zip
           key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
-
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.8
-        with:
-          cmake-version: '3.20.x'
 
       - name: download
         if: steps.cache-source.outputs.cache-hit != 'true'
@@ -65,7 +60,7 @@ jobs:
           key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.8
+        uses: jwlawson/actions-setup-cmake@v1.9
         with:
           cmake-version: '3.20.x'
 
@@ -102,7 +97,7 @@ jobs:
   build-llvm:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/aceforeverd/hybridsql-base:0.0.8
+      image: ghcr.io/aceforeverd/hybridsql-base:0.4.0
     steps:
       - uses: actions/checkout@v2
 
@@ -114,11 +109,6 @@ jobs:
             src/*.tar.*
             src/*.zip
           key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
-
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.8
-        with:
-          cmake-version: '3.20.x'
 
       - name: download
         if: steps.cache-source.outputs.cache-hit != 'true'
@@ -150,7 +140,7 @@ jobs:
           key: ${{ hashFiles('**/CMakeLists.txt', 'fetch_resource.sh') }}
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.8
+        uses: jwlawson/actions-setup-cmake@v1.9
         with:
           cmake-version: '3.20.x'
 
@@ -179,7 +169,7 @@ jobs:
   build-boost:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/aceforeverd/hybridsql-base:0.0.8
+      image: ghcr.io/aceforeverd/hybridsql-base:0.4.0
     steps:
       - uses: actions/checkout@v2
 
@@ -245,8 +235,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: ['build-other', 'build-llvm', 'build-boost',
-    'build-other-mac', 'build-llvm-mac', 'build-boost-mac']
+    needs:
+      - build-other
+      - build-llvm
+      - build-boost
+      - build-other-mac
+      - build-llvm-mac
+      - build-boost-mac
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,10 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: Log into registry
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Log into ghcr registry
         if: github.event_name == 'push'
         uses: docker/login-action@v1
         with:
@@ -34,7 +39,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image
+      - name: Decide the Tag
         if: github.event_name == 'push'
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
@@ -51,8 +56,24 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
 
+          echo "TAG=$IMAGE_ID:$VERSION >> $GITHUB_ENV"
+
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+      - name: Decide Push
+        run: |
+          if [[ ${{ github.event_name = 'push' }} ]]; then
+            echo "PUSH=true >> $GITHUB_ENV"
+          else
+            echo "PUSH=true >> $GITHUB_ENV"
+          fi
+
+      - name: Build And Push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ env.PUSH }}
+          platform: linux/amd64,linux/arm64
+          tags: ${{ env.TAGS }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,19 +62,22 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-      - name: Decide Push
-        run: |
-          if [[ ${{ github.event_name }} = 'push' ]]; then
-            echo "PUSH=true >> $GITHUB_ENV"
-          else
-            echo "PUSH=true >> $GITHUB_ENV"
-          fi
+
+      - name: Build on PR
+        id: docker_build_pr
+        uses: docker/build-push-action@v2
+        if: github.event_name != 'push'
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64,linux/arm64
 
       - name: Build And Push
         id: docker_build
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ env.PUSH }}
-          platform: linux/amd64,linux/arm64
+          push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.TAGS }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,7 +57,7 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
 
-          echo "TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
+          echo "TAGS=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,27 +57,25 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
 
-          echo "TAG=$IMAGE_ID:$VERSION >> $GITHUB_ENV"
+          echo "TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
+      - name: Decide Push
+        run: |
+          if [[ ${{ github.event_name }} = 'push' ]]; then
+            echo "PUSH=true" >> $GITHUB_ENV
+          else
+            echo "PUSH=false" >> $GITHUB_ENV
+          fi
 
-      - name: Build on PR
-        id: docker_build_pr
-        uses: docker/build-push-action@v2
-        if: github.event_name != 'push'
-        with:
-          context: .
-          push: false
-          platforms: linux/amd64,linux/arm64
 
       - name: Build And Push
         id: docker_build
-        if: github.event_name == 'push'
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: ${{ env.PUSH }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ env.TAGS }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,7 @@ on:
       - v*
 
   pull_request:
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: hybridsql-base
@@ -63,7 +64,7 @@ jobs:
 
       - name: Decide Push
         run: |
-          if [[ ${{ github.event_name = 'push' }} ]]; then
+          if [[ ${{ github.event_name }} = 'push' ]]; then
             echo "PUSH=true >> $GITHUB_ENV"
           else
             echo "PUSH=true >> $GITHUB_ENV"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ RUN yum install -y devtoolset-8 rh-git227 flex autoconf automake unzip bc expect
     rh-python38-python-devel gettext byacc xz tcl cppunit-devel rh-python38-python-wheel \
     && yum clean all
 
-RUN curl -SLo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-${TARGETARCH}.tar.gz \
-    && tar xzf cmake.tar.gz -C /usr/local/ --strip-components=1 \
-    && rm -rf cmake.tar.gz
+COPY setup_cmake.sh /
+RUN /setup_cmake.sh ${TARGETARCH} && rm -f setup_cmake.sh
 
 ENV PATH=/opt/rh/rh-git227/root/usr/bin:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin:/opt/rh/devtoolset-8/root/usr/bin:/opt/maven/bin:/depends/thirdparty/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64:/opt/rh/rh-python38/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM centos:7
 
+ARG TARGETARCH
+
 # hadolint ignore=DL3031
 RUN yum update -y && yum install -y centos-release-scl epel-release && yum clean all
 
 RUN yum install -y devtoolset-8 rh-git227 flex autoconf automake unzip bc expect libtool \
     rh-python38-python-devel gettext byacc xz tcl cppunit-devel rh-python38-python-wheel \
     && yum clean all
+
+RUN curl -SLo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-${TARGETARCH}.tar.gz \
+    && tar xzf cmake.tar.gz -C /usr/local/ --strip-components=1 \
+    && rm -rf cmake.tar.gz
 
 ENV PATH=/opt/rh/rh-git227/root/usr/bin:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin:/opt/rh/devtoolset-8/root/usr/bin:/opt/maven/bin:/depends/thirdparty/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64:/opt/rh/rh-python38/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM centos:7
 # hadolint ignore=DL3031
 RUN yum update -y && yum install -y centos-release-scl epel-release && yum clean all
 
-RUN yum install -y devtoolset-8 rh-git218 flex autoconf automake unzip bc expect libtool \
+RUN yum install -y devtoolset-8 rh-git227 flex autoconf automake unzip bc expect libtool \
     rh-python38-python-devel gettext byacc xz tcl cppunit-devel rh-python38-python-wheel \
     && yum clean all
 
-ENV PATH=/opt/rh/rh-git218/root/usr/bin:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin:/opt/rh/devtoolset-8/root/usr/bin:/opt/maven/bin:/depends/thirdparty/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/opt/rh/rh-git227/root/usr/bin:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin:/opt/rh/devtoolset-8/root/usr/bin:/opt/maven/bin:/depends/thirdparty/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64:/opt/rh/rh-python38/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst
 ENV LANG=en_US.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ fetch_resource.sh, then pack_xx.sh, finally pack_all.sh
 
 Note:
 
-You can use `pack_all.sh <WORKDIR> <TARDIR>`
+You can use `pack_all.sh <WORKDIR>`
 
 WORKDIR - The dir to unpack tars and pack together
-
-TARDIR - tars dir, support relative path

--- a/fetch_resource.sh
+++ b/fetch_resource.sh
@@ -67,6 +67,7 @@ fetch https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/
 # leveldb
 fetch https://github.com/google/leveldb/archive/refs/tags/v1.20.tar.gz leveldb-1.20.tar.gz
 # openssl
+fetch https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1k.tar.gz OpenSSL_1_1_1k.tar.gz
 fetch https://github.com/openssl/openssl/archive/OpenSSL_1_1_0.zip OpenSSL_1_1_0.zip
 # glog
 fetch https://github.com/google/glog/archive/refs/tags/v0.4.0.tar.gz glog-0.4.0.tar.gz

--- a/fetch_resource.sh
+++ b/fetch_resource.sh
@@ -26,15 +26,14 @@ cd "$(dirname "$0")"
 
 DOWNLOAD_DIR=${1:-"$PWD/src"}
 
-fetch()
-{
+fetch() {
     if [ $# -ne 2 ]; then
         echo "usage: fetch url output_file"
         exit 1
     fi
     local url=$1
     local file_name=$2
-    if [ ! -e  "$file_name" ]; then
+    if [ ! -e "$file_name" ]; then
         echo -e "${GREEN}downloading $url ...${NC}"
         curl -SL -o "$file_name" "$url"
         echo -e "${GREEN}download $url${NC}"

--- a/fetch_resource.sh
+++ b/fetch_resource.sh
@@ -59,7 +59,9 @@ fetch https://src.fedoraproject.org/lookaside/pkgs/snappy/snappy-1.1.1.tar.gz/88
 
 # gflags
 fetch https://github.com/gflags/gflags/archive/refs/tags/v2.2.0.tar.gz gflags-2.2.0.tar.gz
-# libunwind
+
+# libunwind, use 1.5.0 only for aarch64 build
+fetch https://github.com/libunwind/libunwind/archive/refs/tags/v1.1.tar.gz libunwind-1.1.tar.gz
 fetch https://github.com/libunwind/libunwind/releases/download/v1.5/libunwind-1.5.0.tar.gz libunwind-1.5.0.tar.gz
 # gperftools
 fetch https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz gperftools-2.5.tar.gz
@@ -71,7 +73,9 @@ fetch https://github.com/openssl/openssl/archive/OpenSSL_1_1_0.zip OpenSSL_1_1_0
 fetch https://github.com/google/glog/archive/refs/tags/v0.4.0.tar.gz glog-0.4.0.tar.gz
 # bison
 fetch https://ftp.gnu.org/gnu/bison/bison-3.4.tar.gz bison-3.4.tar.gz
-# absl
+
+# absl, use 2e94e5b6e152df9fa9c2fe8c1b96e1393973d32c only for aarch64 build
+fetch https://github.com/abseil/abseil-cpp/archive/a50ae369a30f99f79d7559002aba3413dac1bd48.tar.gz absl.tar.gz
 fetch https://github.com/abseil/abseil-cpp/archive/2e94e5b6e152df9fa9c2fe8c1b96e1393973d32c.zip absl.zip
 
 # swig

--- a/fetch_resource.sh
+++ b/fetch_resource.sh
@@ -38,6 +38,8 @@ fetch()
         echo -e "${GREEN}downloading $url ...${NC}"
         curl -SL -o "$file_name" "$url"
         echo -e "${GREEN}download $url${NC}"
+    else
+        echo "$file_name" already downloaded
     fi
 }
 
@@ -58,7 +60,7 @@ fetch https://src.fedoraproject.org/lookaside/pkgs/snappy/snappy-1.1.1.tar.gz/88
 # gflags
 fetch https://github.com/gflags/gflags/archive/refs/tags/v2.2.0.tar.gz gflags-2.2.0.tar.gz
 # libunwind
-fetch https://github.com/libunwind/libunwind/archive/refs/tags/v1.1.tar.gz libunwind-1.1.tar.gz
+fetch https://github.com/libunwind/libunwind/releases/download/v1.5/libunwind-1.5.0.tar.gz libunwind-1.5.0.tar.gz
 # gperftools
 fetch https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz gperftools-2.5.tar.gz
 # leveldb
@@ -70,7 +72,7 @@ fetch https://github.com/google/glog/archive/refs/tags/v0.4.0.tar.gz glog-0.4.0.
 # bison
 fetch https://ftp.gnu.org/gnu/bison/bison-3.4.tar.gz bison-3.4.tar.gz
 # absl
-fetch https://github.com/abseil/abseil-cpp/archive/a50ae369a30f99f79d7559002aba3413dac1bd48.tar.gz absl.tar.gz
+fetch https://github.com/abseil/abseil-cpp/archive/2e94e5b6e152df9fa9c2fe8c1b96e1393973d32c.zip absl.zip
 
 # swig
 fetch https://github.com/swig/swig/archive/v4.0.1.tar.gz swig-4.0.1.tar.gz
@@ -101,7 +103,5 @@ fetch https://archive.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.1
 
 # baidu common
 fetch https://github.com/4paradigm/common/archive/refs/tags/v1.0.0.tar.gz common-1.0.0.tar.gz
-
-fetch https://github.com/google/zetasql/archive/5ccb05880e72ab9ff75dd6b05d7b0acce53f1ea2.zip zetasql.zip
 
 popd

--- a/pack_all.sh
+++ b/pack_all.sh
@@ -22,7 +22,7 @@ SRC_DIR="thirdsrc-$(date +%Y-%m-%d)"
 export OUT="$ROOT/$WORKDIR/$INSTALL_DIR"
 unpack_and_install() {
     local name=$1
-    find "$TARDIR" -maxdepth 1 -type f -iname "$name*.tar.gz" -exec tar xzf {} -C "$OUT" --strip-components=1 \;
+    find . -maxdepth 1 -type f -iname "$name*.tar.gz" -exec tar xzf {} -C "$OUT" --strip-components=1 \;
 }
 
 mkdir -p "$OUT"
@@ -40,7 +40,7 @@ popd
 tar czf "$INSTALL_DIR.tar.gz" "$INSTALL_DIR"
 
 mkdir -p "$SRC_DIR"
-tar xzf "$TARDIR"/src/apache-zookeeper-*.tar.gz -C "$SRC_DIR"
+tar xzf src/apache-zookeeper-*.tar.gz -C "$SRC_DIR"
 tar czf "$SRC_DIR.tar.gz" "$SRC_DIR"
 
 popd

--- a/pack_all.sh
+++ b/pack_all.sh
@@ -12,8 +12,8 @@ cd "$(dirname "$0")"
 source var.sh
 
 WORKDIR=${1:-.}
-OS=${OS:-$(os_type)}
-ARCH=${ARCH:-$(arch)}
+OS=$(os_type)
+ARCH=$(target_arch)
 
 ROOT=$(pwd)
 INSTALL_DIR="thirdparty-$OS-$ARCH-$(date +%Y-%m-%d)"

--- a/pack_all.sh
+++ b/pack_all.sh
@@ -1,37 +1,33 @@
 #!/bin/bash
 
+# merge llvm, boost, and other build artifcats into single archive
+# pack_all.sh accept one extra argument indicate which directory those sub packages locate
+# by default, sub packages consider exist in the same directory as pack_all.sh
+
 set -eE
 set -x
 
 cd "$(dirname "$0")"
 
-ROOT=$(pwd)
-WORKDIR=${1:-artifact}
-INSTALL_DIR="thirdparty-$(date +%Y-%m-%d)"
-SRC_DIR="thirdsrc-$(date +%Y-%m-%d)"
+source var.sh
 
-TARDIR=${2:-$WORKDIR}
-pushd "$TARDIR"
-TARDIR=$(pwd)
-echo "tars dir: $TARDIR"
-popd
+WORKDIR=${1:-.}
+OS=${OS:-$(os_type)}
+ARCH=${ARCH:-$(arch)}
+
+ROOT=$(pwd)
+INSTALL_DIR="thirdparty-$OS-$ARCH-$(date +%Y-%m-%d)"
+SRC_DIR="thirdsrc-$(date +%Y-%m-%d)"
 
 export OUT="$ROOT/$WORKDIR/$INSTALL_DIR"
 unpack_and_install() {
     local name=$1
-    find "$TARDIR" -maxdepth 1 -type f -iname "$name*.tar.gz" -exec tar xzf {} \;
-    pushd "$name"-*/
-
-    # Mac install(1) doesn't support -D, so we create dirs first, then copy
-    find . -type d -exec install -d {} "$OUT"/{} \;
-    find . -type f -exec install {} "$OUT"/{} \;
-    popd
+    find "$TARDIR" -maxdepth 1 -type f -iname "$name*.tar.gz" -exec tar xzf {} -C "$OUT" --strip-components=1 \;
 }
 
-mkdir -p "$WORKDIR"
-pushd "$WORKDIR"
+mkdir -p "$OUT"
 
-mkdir -p "$INSTALL_DIR"
+pushd "$WORKDIR"
 
 unpack_and_install boost
 unpack_and_install llvm

--- a/pack_all.sh
+++ b/pack_all.sh
@@ -16,7 +16,7 @@ OS=$(os_type)
 ARCH=$(target_arch)
 
 ROOT=$(pwd)
-INSTALL_DIR="thirdparty-$OS-$ARCH-$(date +%Y-%m-%d)"
+INSTALL_DIR="thirdparty-$(date +%Y-%m-%d)-$OS-$ARCH"
 SRC_DIR="thirdsrc-$(date +%Y-%m-%d)"
 
 export OUT="$ROOT/$WORKDIR/$INSTALL_DIR"

--- a/pack_all.sh
+++ b/pack_all.sh
@@ -34,9 +34,6 @@ unpack_and_install llvm
 unpack_and_install libother
 
 # needs a soft link lib64->lib for Mac OS
-pushd "$INSTALL_DIR"
-ln -s lib lib64
-popd
 tar czf "$INSTALL_DIR.tar.gz" "$INSTALL_DIR"
 
 mkdir -p "$SRC_DIR"

--- a/pack_all.sh
+++ b/pack_all.sh
@@ -11,7 +11,7 @@ INSTALL_DIR="thirdparty-$(date +%Y-%m-%d)"
 SRC_DIR="thirdsrc-$(date +%Y-%m-%d)"
 
 TARDIR=${2:-$WORKDIR}
-pushd $TARDIR
+pushd "$TARDIR"
 TARDIR=$(pwd)
 echo "tars dir: $TARDIR"
 popd
@@ -19,7 +19,7 @@ popd
 export OUT="$ROOT/$WORKDIR/$INSTALL_DIR"
 unpack_and_install() {
     local name=$1
-    find $TARDIR -maxdepth 1 -type f -iname "$name*.tar.gz" -exec tar xzf {} \;
+    find "$TARDIR" -maxdepth 1 -type f -iname "$name*.tar.gz" -exec tar xzf {} \;
     pushd "$name"-*/
 
     # Mac install(1) doesn't support -D, so we create dirs first, then copy
@@ -28,7 +28,7 @@ unpack_and_install() {
     popd
 }
 
-mkdir -p $WORKDIR
+mkdir -p "$WORKDIR"
 pushd "$WORKDIR"
 
 mkdir -p "$INSTALL_DIR"
@@ -44,7 +44,7 @@ popd
 tar czf "$INSTALL_DIR.tar.gz" "$INSTALL_DIR"
 
 mkdir -p "$SRC_DIR"
-tar xzf $TARDIR/src/apache-zookeeper-*.tar.gz -C "$SRC_DIR"
+tar xzf "$TARDIR"/src/apache-zookeeper-*.tar.gz -C "$SRC_DIR"
 tar czf "$SRC_DIR.tar.gz" "$SRC_DIR"
 
 popd

--- a/pack_boost.sh
+++ b/pack_boost.sh
@@ -4,17 +4,16 @@
 
 set -e
 
-
 cd "$(dirname "$0")"
 
 VERSION=1.69.0
 
-if [ -d '/opt/rh/devtoolset-8' ] ; then
+if [ -d '/opt/rh/devtoolset-8' ]; then
     # shellcheck disable=SC1091
     source /opt/rh/devtoolset-8/enable
 fi
 
-if [ -d '/opt/rh/rh-python38' ] ; then
+if [ -d '/opt/rh/rh-python38' ]; then
     # shellcheck disable=SC1091
     source /opt/rh/rh-python38/enable
 fi
@@ -42,8 +41,8 @@ tar xzf common-1.0.0.tar.gz
 pushd common-1.0.0/
 if [[ "${OS}" = "darwin" ]]; then
     # 'syscall' is deprecated: first deprecated in OS X 10.12
-	sed -i '' 's/^#include <syscall.h>/#include <pthread.h>/' src/logging.cc
-	sed -i '' 's/thread_id = syscall(__NR_gettid)/pthread_threadid_np(0, \&thread_id)/' src/logging.cc
+    sed -i '' 's/^#include <syscall.h>/#include <pthread.h>/' src/logging.cc
+    sed -i '' 's/thread_id = syscall(__NR_gettid)/pthread_threadid_np(0, \&thread_id)/' src/logging.cc
 fi
 make $MAKEOPTS INCLUDE_PATH="-Iinclude -I$DEPS_PREFIX/include" PREFIX="$DEPS_PREFIX" install
 

--- a/pack_boost.sh
+++ b/pack_boost.sh
@@ -20,7 +20,7 @@ if [ -d '/opt/rh/rh-python38' ] ; then
 fi
 
 source var.sh
-ARCH=$(os_type)
+OS=$(os_type)
 
 DEPS_SOURCE="$PWD/src"
 DEPS_PREFIX="$PWD/boost-$VERSION"
@@ -29,7 +29,7 @@ pushd "$DEPS_SOURCE"
 
 tar -zxf boost_1_69_0.tar.gz
 pushd boost_1_69_0
-if [[ "${ARCH}" = "darwin" ]]; then
+if [[ "${OS}" = "darwin" ]]; then
     ./bootstrap.sh compiler.blacklist clang -with-toolset=clang
 else
     ./bootstrap.sh
@@ -40,7 +40,7 @@ popd
 
 tar xzf common-1.0.0.tar.gz
 pushd common-1.0.0
-if [[ "${ARCH}" = "darwin" ]]; then
+if [[ "${OS}" = "darwin" ]]; then
     # 'syscall' is deprecated: first deprecated in OS X 10.12
 	sed -i '' 's/^#include <syscall.h>/#include <pthread.h>/' src/logging.cc
 	sed -i '' 's/thread_id = syscall(__NR_gettid)/pthread_threadid_np(0, \&thread_id)/' src/logging.cc

--- a/pack_boost.sh
+++ b/pack_boost.sh
@@ -25,10 +25,10 @@ OS=$(os_type)
 DEPS_SOURCE="$PWD/src"
 DEPS_PREFIX="$PWD/boost-$VERSION"
 
-pushd "$DEPS_SOURCE"
+pushd "$DEPS_SOURCE"/
 
 tar -zxf boost_1_69_0.tar.gz
-pushd boost_1_69_0
+pushd boost_1_69_0/
 if [[ "${OS}" = "darwin" ]]; then
     ./bootstrap.sh compiler.blacklist clang -with-toolset=clang
 else
@@ -39,13 +39,13 @@ fi
 popd
 
 tar xzf common-1.0.0.tar.gz
-pushd common-1.0.0
+pushd common-1.0.0/
 if [[ "${OS}" = "darwin" ]]; then
     # 'syscall' is deprecated: first deprecated in OS X 10.12
 	sed -i '' 's/^#include <syscall.h>/#include <pthread.h>/' src/logging.cc
 	sed -i '' 's/thread_id = syscall(__NR_gettid)/pthread_threadid_np(0, \&thread_id)/' src/logging.cc
 fi
-make -j"$(nproc)" INCLUDE_PATH="-Iinclude -I$DEPS_PREFIX/include" PREFIX="$DEPS_PREFIX" install
+make $MAKEOPTS INCLUDE_PATH="-Iinclude -I$DEPS_PREFIX/include" PREFIX="$DEPS_PREFIX" install
 
 popd
 

--- a/pack_boost.sh
+++ b/pack_boost.sh
@@ -29,10 +29,10 @@ pushd "$DEPS_SOURCE"
 
 tar -zxf boost_1_69_0.tar.gz
 pushd boost_1_69_0
-if [[ "${ARCH}" == "Mac" ]]; then
+if [[ "${ARCH}" = "darwin" ]]; then
     ./bootstrap.sh compiler.blacklist clang -with-toolset=clang
 else
-    ./bootstrap.sh 
+    ./bootstrap.sh
 fi
 ./b2 link=static cxxflags=-fPIC cflags=-fPIC release install --prefix="$DEPS_PREFIX"
 
@@ -40,7 +40,7 @@ popd
 
 tar xzf common-1.0.0.tar.gz
 pushd common-1.0.0
-if [[ "${ARCH}" == "Mac" ]]; then
+if [[ "${ARCH}" = "darwin" ]]; then
     # 'syscall' is deprecated: first deprecated in OS X 10.12
 	sed -i '' 's/^#include <syscall.h>/#include <pthread.h>/' src/logging.cc
 	sed -i '' 's/thread_id = syscall(__NR_gettid)/pthread_threadid_np(0, \&thread_id)/' src/logging.cc

--- a/pack_llvm.sh
+++ b/pack_llvm.sh
@@ -19,10 +19,10 @@ fi
 DEPS_SOURCE="$PWD/src"
 DEPS_PREFIX="$PWD/llvm-$VERSION"
 
-if [[ $(arch) = 'aarch64' ]]; then
+if [[ $(target_arch) = 'aarch64' ]]; then
     LLVM_TARGETS="AArch64"
-elif [[ $(arch) = 'x86'* ]]; then
-    LLVM_TARGETS="x86"
+elif [[ $(target_arch) = 'x86'* ]]; then
+    LLVM_TARGETS="X86"
 else
     LLVM_TARGETS=all
 fi

--- a/pack_llvm.sh
+++ b/pack_llvm.sh
@@ -19,12 +19,21 @@ fi
 DEPS_SOURCE="$PWD/src"
 DEPS_PREFIX="$PWD/llvm-$VERSION"
 
+if [[ $(arch) = 'aarch64' ]]; then
+    LLVM_TARGETS="AArch64"
+elif [[ $(arch) = 'x86'* ]]; then
+    LLVM_TARGETS="x86"
+else
+    LLVM_TARGETS=all
+fi
+
 pushd "$DEPS_SOURCE"
 
 tar xf llvm-$VERSION.src.tar.xz
 pushd llvm-$VERSION.src
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DLLVM_TARGETS_TO_BUILD=X86  -DCMAKE_CXX_FLAGS=-fPIC ..
+
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGETS"  -DCMAKE_CXX_FLAGS=-fPIC ..
 make "-j$(nproc)"
 make install
 popd

--- a/pack_llvm.sh
+++ b/pack_llvm.sh
@@ -8,12 +8,12 @@ source var.sh
 
 VERSION=9.0.0
 
-if [ -d '/opt/rh/devtoolset-8' ] ; then
+if [ -d '/opt/rh/devtoolset-8' ]; then
     # shellcheck disable=SC1091
     source /opt/rh/devtoolset-8/enable
 fi
 
-if [ -d '/opt/rh/rh-python38' ] ; then
+if [ -d '/opt/rh/rh-python38' ]; then
     # shellcheck disable=SC1091
     source /opt/rh/rh-python38/enable
 fi
@@ -39,7 +39,7 @@ tar xf llvm-$VERSION.src.tar.xz
 pushd llvm-$VERSION.src/
 mkdir -p build && cd build
 
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGETS"  -DCMAKE_CXX_FLAGS=-fPIC ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGETS" -DCMAKE_CXX_FLAGS=-fPIC ..
 make $MAKEOPTS
 make install
 popd

--- a/pack_llvm.sh
+++ b/pack_llvm.sh
@@ -4,6 +4,8 @@ set -e
 
 cd "$(dirname "$0")"
 
+source var.sh
+
 VERSION=9.0.0
 
 if [ -d '/opt/rh/devtoolset-8' ] ; then
@@ -27,14 +29,14 @@ else
     LLVM_TARGETS=all
 fi
 
-pushd "$DEPS_SOURCE"
+pushd "$DEPS_SOURCE"/
 
 tar xf llvm-$VERSION.src.tar.xz
-pushd llvm-$VERSION.src
+pushd llvm-$VERSION.src/
 mkdir -p build && cd build
 
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGETS"  -DCMAKE_CXX_FLAGS=-fPIC ..
-make "-j$(nproc)"
+make $MAKEOPTS
 make install
 popd
 

--- a/pack_llvm.sh
+++ b/pack_llvm.sh
@@ -21,13 +21,17 @@ fi
 DEPS_SOURCE="$PWD/src"
 DEPS_PREFIX="$PWD/llvm-$VERSION"
 
-if [[ $(target_arch) = 'aarch64' ]]; then
+ARCH=$(target_arch)
+
+if [[ $ARCH = 'aarch64' ]]; then
     LLVM_TARGETS="AArch64"
-elif [[ $(target_arch) = 'x86'* ]]; then
+elif [[ $ARCH = 'x86'* || $ARCH = 'i386' ]]; then
     LLVM_TARGETS="X86"
 else
     LLVM_TARGETS=all
 fi
+
+echo "LLVM_TARGETS: $LLVM_TARGETS"
 
 pushd "$DEPS_SOURCE"/
 

--- a/pack_other.sh
+++ b/pack_other.sh
@@ -186,8 +186,14 @@ fi
 if [ -f "openssl_succ" ]; then
     echo "openssl exist"
 else
-    unzip OpenSSL_1_1_0.zip
-    pushd openssl-OpenSSL_1_1_0
+    if [[ $ARCH = 'aarch64' ]]; then
+        # static link issue in arm64: https://github.com/openssl/openssl/issues/10842
+        tar xzf OpenSSL_1_1_1k.tar.gz
+        pushd openssl-OpenSSL_1_1_1k/
+    else
+        unzip OpenSSL_1_1_0.zip
+        pushd openssl-OpenSSL_1_1_0
+    fi
     # On Mac OS, sed must use `-i extension` for saving backups with the specified extension.
     # But we can give a zero-length extension, no backup will be saved.
     sed -i'' -e 's#qw/glob#qw/:glob#' Configure

--- a/pack_other.sh
+++ b/pack_other.sh
@@ -21,12 +21,12 @@ set -eE
 
 cd "$(dirname "$0")"
 
-if [ -d '/opt/rh/devtoolset-8' ] ; then
+if [ -d '/opt/rh/devtoolset-8' ]; then
     # shellcheck disable=SC1091
     source /opt/rh/devtoolset-8/enable
 fi
 
-if [ -d '/opt/rh/rh-python38' ] ; then
+if [ -d '/opt/rh/rh-python38' ]; then
     # shellcheck disable=SC1091
     source /opt/rh/rh-python38/enable
 fi
@@ -50,159 +50,160 @@ export PATH=${DEPS_PREFIX}/bin:$PATH
 pushd "$DEPS_SOURCE"/
 
 if [ ! -f gtest_succ ]; then
-	echo "installing gtest ...."
-	tar xzf googletest-release-1.11.0.tar.gz
+    echo "installing gtest ...."
+    tar xzf googletest-release-1.11.0.tar.gz
 
-	pushd googletest-release-1.11.0
-	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DCMAKE_CXX_FLAGS=-fPIC
+    pushd googletest-release-1.11.0
+    cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DCMAKE_CXX_FLAGS=-fPIC
     cmake --build build -- $MAKEOPTS
     cmake --build build --target install
-	popd
+    popd
 
-	touch gtest_succ
-	echo "install gtest done"
+    touch gtest_succ
+    echo "install gtest done"
 fi
 
 if [ -f "glog_succ" ]; then
-	echo "glog exist"
+    echo "glog exist"
 else
-	echo "installing glog ..."
-	tar xzf glog-0.4.0.tar.gz
-	pushd glog-0.4.0
-	./autogen.sh && CXXFLAGS=-fPIC ./configure --prefix="$DEPS_PREFIX" --enable-shared=no
-	make $MAKEOPTS install
-	popd
-	touch glog_succ
-	echo "installed glog"
+    echo "installing glog ..."
+    tar xzf glog-0.4.0.tar.gz
+    pushd glog-0.4.0
+    ./autogen.sh && CXXFLAGS=-fPIC ./configure --prefix="$DEPS_PREFIX" --enable-shared=no
+    make $MAKEOPTS install
+    popd
+    touch glog_succ
+    echo "installed glog"
 fi
 
 if [ -f "gflags_succ" ]; then
-	echo "gflags-2.2.0.tar.gz exist"
+    echo "gflags-2.2.0.tar.gz exist"
 else
-	tar zxf gflags-2.2.0.tar.gz
-	pushd gflags-2.2.0
-	# Mac will failed in create build/ cuz the dir contains a file named 'BUILD', so we use 'cmake_build' as the build dir.
-	# gflags BUILD_SHARED_LIBS default is OFF. And if BUILD_SHARED_LIBS=OFF, BUILD_STATIC_LIBS will be ON.
-	cmake -H. -Bcmake_build -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DGFLAGS_NAMESPACE=google -DCMAKE_CXX_FLAGS=-fPIC
-	cmake --build cmake_build -- $MAKEOPTS
+    tar zxf gflags-2.2.0.tar.gz
+    pushd gflags-2.2.0
+    # Mac will failed in create build/ cuz the dir contains a file named 'BUILD', so we use 'cmake_build' as the build dir.
+    # gflags BUILD_SHARED_LIBS default is OFF. And if BUILD_SHARED_LIBS=OFF, BUILD_STATIC_LIBS will be ON.
+    cmake -H. -Bcmake_build -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DGFLAGS_NAMESPACE=google -DCMAKE_CXX_FLAGS=-fPIC
+    cmake --build cmake_build -- $MAKEOPTS
     cmake --build cmake_build --target install
-	popd
+    popd
 
-	touch gflags_succ
-	echo "install gflags done"
+    touch gflags_succ
+    echo "install gflags done"
 fi
 
 if [ -f "zlib_succ" ]; then
-	echo "zlib exist"
+    echo "zlib exist"
 else
-	echo "installing zlib..."
-	tar xzf zlib-1.2.11.tar.gz
-	pushd zlib-1.2.11
-	CFLAGS="-O3 -fPIC" ./configure --static --prefix="$DEPS_PREFIX"
-	make $MAKEOPTS
-	make install
-	popd
-	touch zlib_succ
-	echo "install zlib done"
+    echo "installing zlib..."
+    tar xzf zlib-1.2.11.tar.gz
+    pushd zlib-1.2.11
+    CFLAGS="-O3 -fPIC" ./configure --static --prefix="$DEPS_PREFIX"
+    make $MAKEOPTS
+    make install
+    popd
+    touch zlib_succ
+    echo "install zlib done"
 fi
 
 if [ -f "protobuf_succ" ]; then
-	echo "protobuf exist"
+    echo "protobuf exist"
 else
-	echo "start install protobuf ..."
-	tar zxf protobuf-3.6.1.3.tar.gz
+    echo "start install protobuf ..."
+    tar zxf protobuf-3.6.1.3.tar.gz
 
-	pushd protobuf-*/
+    pushd protobuf-*/
     ./autogen.sh && ./configure --disable-shared --with-pic --prefix "${DEPS_PREFIX}" CPPFLAGS=-I"$DEPS_PREFIX/include" LDFLAGS=-L"$DEPS_PREFIX/lib"
-	make $MAKEOPTS
-	make install
-	popd
+    make $MAKEOPTS
+    make install
+    popd
 
-	touch protobuf_succ
-	echo "install protobuf done"
+    touch protobuf_succ
+    echo "install protobuf done"
 fi
 
 if [ -f "snappy_succ" ]; then
-	echo "snappy exist"
+    echo "snappy exist"
 else
-	echo "start install snappy ..."
-	tar zxf snappy-1.1.1.tar.gz
-	pushd snappy-1.1.1/
-	./configure $DEPS_CONFIG
-	make $MAKEOPTS
-	make install
-	popd
+    echo "start install snappy ..."
+    tar zxf snappy-1.1.1.tar.gz
+    pushd snappy-1.1.1/
+    ./configure $DEPS_CONFIG
+    make $MAKEOPTS
+    make install
+    popd
 
-	touch snappy_succ
-	echo "install snappy done"
+    touch snappy_succ
+    echo "install snappy done"
 fi
 
 if [[ -f "unwind_succ" ]]; then
-	echo "unwind_exist"
+    echo "unwind_exist"
 elif [[ $OS = "darwin" ]]; then
-	echo "For Mac, libunwind doesn't need to be built separately"
+    echo "For Mac, libunwind doesn't need to be built separately"
 else
     if [[ $ARCH = 'aarch64' ]]; then
         tar zxf libunwind-1.5.0.tar.gz
-	    pushd libunwind-1.5.0/
+        pushd libunwind-1.5.0/
     else
         tar xzf libunwind-1.1.tar.gz
-	    pushd libunwind-1.1/
+        pushd libunwind-1.1/
+        autoreconf -i
     fi
-	./configure --prefix="$DEPS_PREFIX" --enable-shared=no
+    ./configure --prefix="$DEPS_PREFIX" --enable-shared=no
     make $MAKEOPTS
     make install
-	popd
+    popd
 
-	touch unwind_succ
+    touch unwind_succ
 fi
 
 if [ -f "gperf_succ" ]; then
-	echo "gperf_succ exist"
+    echo "gperf_succ exist"
 else
-	tar zxf gperftools-2.5.tar.gz
-	pushd gperftools-2.5/
-	./configure --enable-cpu-profiler --enable-heap-checker --enable-heap-profiler --prefix="$DEPS_PREFIX" --enable-shared=no
-	make $MAKEOPTS
-	make install
-	popd
-	touch gperf_succ
+    tar zxf gperftools-2.5.tar.gz
+    pushd gperftools-2.5/
+    ./configure --enable-cpu-profiler --enable-heap-checker --enable-heap-profiler --prefix="$DEPS_PREFIX" --enable-shared=no
+    make $MAKEOPTS
+    make install
+    popd
+    touch gperf_succ
 fi
 
 if [ -f "leveldb_succ" ]; then
-	echo "leveldb exist"
+    echo "leveldb exist"
 else
     # TODO fix compile on leveldb 1.23
-	tar zxf leveldb-1.20.tar.gz
-	pushd leveldb-1.20
-	make $MAKEOPTS OPT="-O2 -DNDEBUG -fPIC"
-	cp -rf include/* "$DEPS_PREFIX/include"
-	cp out-static/libleveldb.a "$DEPS_PREFIX/lib"
-	popd
-	touch leveldb_succ
+    tar zxf leveldb-1.20.tar.gz
+    pushd leveldb-1.20
+    make $MAKEOPTS OPT="-O2 -DNDEBUG -fPIC"
+    cp -rf include/* "$DEPS_PREFIX/include"
+    cp out-static/libleveldb.a "$DEPS_PREFIX/lib"
+    popd
+    touch leveldb_succ
 fi
 
 if [ -f "openssl_succ" ]; then
-	echo "openssl exist"
+    echo "openssl exist"
 else
-	unzip OpenSSL_1_1_0.zip
-	pushd openssl-OpenSSL_1_1_0
-	# On Mac OS, sed must use `-i extension` for saving backups with the specified extension.
-	# But we can give a zero-length extension, no backup will be saved.
-	sed -i'' -e 's#qw/glob#qw/:glob#' Configure
-	sed -i'' -e 's#qw/glob#qw/:glob#' test/build.info
+    unzip OpenSSL_1_1_0.zip
+    pushd openssl-OpenSSL_1_1_0
+    # On Mac OS, sed must use `-i extension` for saving backups with the specified extension.
+    # But we can give a zero-length extension, no backup will be saved.
+    sed -i'' -e 's#qw/glob#qw/:glob#' Configure
+    sed -i'' -e 's#qw/glob#qw/:glob#' test/build.info
     if [[ $ARCH = aarch64 ]]; then
         ./config --prefix="$DEPS_PREFIX" --openssldir="$DEPS_PREFIX" no-afalgeng no-shared
     else
         ./config --prefix="$DEPS_PREFIX" --openssldir="$DEPS_PREFIX" no-shared
     fi
-	make $MAKEOPTS
-	make install
-	rm -rf "$DEPS_PREFIX"/lib/libssl.so*
-	rm -rf "$DEPS_PREFIX"/lib/libcrypto.so*
-	popd
-	touch openssl_succ
-	echo "openssl done"
+    make $MAKEOPTS
+    make install
+    rm -rf "$DEPS_PREFIX"/lib/libssl.so*
+    rm -rf "$DEPS_PREFIX"/lib/libcrypto.so*
+    popd
+    touch openssl_succ
+    echo "openssl done"
 fi
 
 if [[ $ARCH = 'aarch64' ]]; then
@@ -221,87 +222,87 @@ cmake --build build --target install
 popd
 
 if [ -f "brpc_succ" ]; then
-	echo "brpc exist"
+    echo "brpc exist"
 else
-	unzip incubator-brpc.zip
-	pushd incubator-brpc-*/
+    unzip incubator-brpc.zip
+    pushd incubator-brpc-*/
     if [[ $ARCH = aarch64 ]]; then
         # those options not exist on arm
         sed -e '/CXXFLAGS+=-msse4 -msse4.2/s/^/#/' -i Makefile
     fi
-	sh config_brpc.sh --with-glog --headers="$DEPS_PREFIX/include" --libs="$DEPS_PREFIX/lib"
-	make $MAKEOPTS libbrpc.a output/include
-	cp -rf output/include/* "$DEPS_PREFIX/include/"
-	cp libbrpc.a "$DEPS_PREFIX/lib"
-	popd
+    sh config_brpc.sh --with-glog --headers="$DEPS_PREFIX/include" --libs="$DEPS_PREFIX/lib"
+    make $MAKEOPTS libbrpc.a output/include
+    cp -rf output/include/* "$DEPS_PREFIX/include/"
+    cp libbrpc.a "$DEPS_PREFIX/lib"
+    popd
 
-	touch brpc_succ
-	echo "brpc done"
+    touch brpc_succ
+    echo "brpc done"
 fi
 
 if [ -f "bison_succ" ]; then
-	echo "bison exist"
+    echo "bison exist"
 else
-	tar zxf bison-3.4.tar.gz
-	pushd bison-3.4
-	./configure --prefix="$DEPS_PREFIX" --enable-relocatable
-	make install
-	popd
-	touch bison_succ
+    tar zxf bison-3.4.tar.gz
+    pushd bison-3.4
+    ./configure --prefix="$DEPS_PREFIX" --enable-relocatable
+    make install
+    popd
+    touch bison_succ
 fi
 
 if [ -f "benchmark_succ" ]; then
-	echo "benchmark exist"
+    echo "benchmark exist"
 else
-	tar zxf v1.5.0.tar.gz
-	pushd benchmark-1.5.0
-	mkdir -p build
-	cd build
-	cmake -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DCMAKE_CXX_FLAGS=-fPIC -DBENCHMARK_ENABLE_GTEST_TESTS=OFF ..
-	make $MAKEOPTS
-	make install
-	popd
-	touch benchmark_succ
+    tar zxf v1.5.0.tar.gz
+    pushd benchmark-1.5.0
+    mkdir -p build
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" -DCMAKE_CXX_FLAGS=-fPIC -DBENCHMARK_ENABLE_GTEST_TESTS=OFF ..
+    make $MAKEOPTS
+    make install
+    popd
+    touch benchmark_succ
 fi
 
 if [ -f "swig_succ" ]; then
-	echo "swig exist"
+    echo "swig exist"
 else
-	tar -zxf swig-4.0.1.tar.gz
-	pushd swig-4.0.1
-	./autogen.sh
-	./configure --without-pcre --prefix="$DEPS_PREFIX"
-	make $MAKEOPTS
-	make install
-	popd
-	touch swig_succ
+    tar -zxf swig-4.0.1.tar.gz
+    pushd swig-4.0.1
+    ./autogen.sh
+    ./configure --without-pcre --prefix="$DEPS_PREFIX"
+    make $MAKEOPTS
+    make install
+    popd
+    touch swig_succ
 fi
 
 if [ -f "yaml_succ" ]; then
-	echo "yaml-cpp installed"
+    echo "yaml-cpp installed"
 else
-	tar -zxf yaml-cpp-0.6.3.tar.gz
-	pushd yaml-cpp-yaml-cpp-0.6.3
-	mkdir -p build
-	cd build
-	cmake -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" ..
-	make $MAKEOPTS
-	make install
-	popd
-	touch yaml_succ
+    tar -zxf yaml-cpp-0.6.3.tar.gz
+    pushd yaml-cpp-yaml-cpp-0.6.3
+    mkdir -p build
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX="$DEPS_PREFIX" ..
+    make $MAKEOPTS
+    make install
+    popd
+    touch yaml_succ
 fi
 
 if [ -f "sqlite_succ" ]; then
-	echo "sqlite installed"
+    echo "sqlite installed"
 else
-	unzip sqlite-*.zip
-	pushd sqlite-version-3.32.3
-	mkdir -p build
-	cd build
-	../configure --prefix="$DEPS_PREFIX" --disable-tcl --enable-shared=no
-	make $MAKEOPTS && make install
-	popd
-	touch sqlite_succ
+    unzip sqlite-*.zip
+    pushd sqlite-version-3.32.3
+    mkdir -p build
+    cd build
+    ../configure --prefix="$DEPS_PREFIX" --disable-tcl --enable-shared=no
+    make $MAKEOPTS && make install
+    popd
+    touch sqlite_succ
 fi
 
 if [ -f zookeeper_succ ]; then
@@ -315,11 +316,11 @@ else
         autoreconf -if
         # see https://issues.apache.org/jira/browse/ZOOKEEPER-3293
         CFLAGS="$CFLAGS -Wno-error=format-overflow=" ./configure --prefix="$DEPS_PREFIX" --enable-shared=no
-        fi
+    fi
 
-        make $MAKEOPTS
-        make install
-        popd
+    make $MAKEOPTS
+    make install
+    popd
 fi
 
 popd

--- a/pack_other.sh
+++ b/pack_other.sh
@@ -33,7 +33,7 @@ if [ -d '/opt/rh/rh-python38' ] ; then
 fi
 
 source var.sh
-ARCH=$(os_type)
+OS=$(os_type)
 
 VERSION=$(date +%Y-%m-%d)
 
@@ -139,7 +139,7 @@ fi
 
 if [[ -f "unwind_succ" ]]; then
 	echo "unwind_exist"
-elif [[ "${ARCH}" == "Mac" ]]; then
+elif [[ $OS = "darwin" ]]; then
 	echo "For Mac, libunwind doesn't need to be built separately"
 else
 	tar zxf libunwind-1.5.0.tar.gz
@@ -296,7 +296,7 @@ fi
 
 tar -zxf apache-zookeeper-3.4.14.tar.gz
 pushd zookeeper-3.4.14/zookeeper-client/zookeeper-client-c
-if [[ "$ARCH" == "Mac" ]]; then
+if [[ $OS = "darwin" ]]; then
 	CC="clang" CFLAGS="$CFLAGS" ./configure --prefix="$DEPS_PREFIX" --enable-shared=no
 else
 	autoreconf -if

--- a/pack_other.sh
+++ b/pack_other.sh
@@ -186,7 +186,7 @@ else
 	# But we can give a zero-length extension, no backup will be saved.
 	sed -i'' -e 's#qw/glob#qw/:glob#' Configure
 	sed -i'' -e 's#qw/glob#qw/:glob#' test/build.info
-    if [[ $(arch) = aarch64 ]]; then
+    if [[ $(target_arch) = aarch64 ]]; then
         ./config --prefix="$DEPS_PREFIX" --openssldir="$DEPS_PREFIX" no-afalgeng no-shared
     else
         ./config --prefix="$DEPS_PREFIX" --openssldir="$DEPS_PREFIX" no-shared
@@ -215,7 +215,7 @@ if [ -f "brpc_succ" ]; then
 else
 	unzip incubator-brpc.zip
 	pushd incubator-brpc-*
-    if [[ $(arch) = aarch64 ]]; then
+    if [[ $(target_arch) = aarch64 ]]; then
         # those options not exist on arm
         sed -e '/CXXFLAGS+=-msse4 -msse4.2/s/^/#/' -i Makefile
     fi

--- a/pack_other.sh
+++ b/pack_other.sh
@@ -144,7 +144,7 @@ elif [[ $OS = "darwin" ]]; then
 else
 	tar zxf libunwind-1.5.0.tar.gz
 	pushd libunwind-1.5.0
-	./configure --prefix="$DEPS_PREFIX"
+	./configure --prefix="$DEPS_PREFIX" --enable-shared=no
     make -j"$(nproc)"
     make install
 	popd

--- a/pack_other.sh
+++ b/pack_other.sh
@@ -190,17 +190,14 @@ else
         # static link issue in arm64: https://github.com/openssl/openssl/issues/10842
         tar xzf OpenSSL_1_1_1k.tar.gz
         pushd openssl-OpenSSL_1_1_1k/
+        ./config --prefix="$DEPS_PREFIX" --openssldir="$DEPS_PREFIX" no-afalgeng no-shared
     else
         unzip OpenSSL_1_1_0.zip
         pushd openssl-OpenSSL_1_1_0
-    fi
-    # On Mac OS, sed must use `-i extension` for saving backups with the specified extension.
-    # But we can give a zero-length extension, no backup will be saved.
-    sed -i'' -e 's#qw/glob#qw/:glob#' Configure
-    sed -i'' -e 's#qw/glob#qw/:glob#' test/build.info
-    if [[ $ARCH = aarch64 ]]; then
-        ./config --prefix="$DEPS_PREFIX" --openssldir="$DEPS_PREFIX" no-afalgeng no-shared
-    else
+        # On Mac OS, sed must use `-i extension` for saving backups with the specified extension.
+        # But we can give a zero-length extension, no backup will be saved.
+        sed -i'' -e 's#qw/glob#qw/:glob#' Configure
+        sed -i'' -e 's#qw/glob#qw/:glob#' test/build.info
         ./config --prefix="$DEPS_PREFIX" --openssldir="$DEPS_PREFIX" no-shared
     fi
     make $MAKEOPTS
@@ -233,8 +230,7 @@ else
     unzip incubator-brpc.zip
     pushd incubator-brpc-*/
     if [[ $ARCH = aarch64 ]]; then
-        # those options not exist on arm
-        sed -e '/CXXFLAGS+=-msse4 -msse4.2/s/^/#/' -i Makefile
+        patch -ruN < "$DEPS_SOURCE/patch/incubator-brpc-aarch64.patch"
     fi
     sh config_brpc.sh --with-glog --headers="$DEPS_PREFIX/include" --libs="$DEPS_PREFIX/lib"
     make $MAKEOPTS libbrpc.a output/include

--- a/pack_other.sh
+++ b/pack_other.sh
@@ -210,7 +210,7 @@ if [[ $ARCH = 'aarch64' ]]; then
     unzip absl.zip
     pushd abseil-cpp-2e94e5b6e152df9fa9c2fe8c1b96e1393973d32c/
 else
-    tar xzf tar xf absl.tar.gz
+    tar xf absl.tar.gz
     pushd abseil-cpp-a50ae369a30f99f79d7559002aba3413dac1bd48/
 fi
 cmake -H. -Bbuild -DCMAKE_INSTALL_LIBDIR=lib \

--- a/patch/incubator-brpc-aarch64.patch
+++ b/patch/incubator-brpc-aarch64.patch
@@ -1,0 +1,20 @@
+--- Makefile	2021-08-02 15:05:38.000000000 +0800
++++ Makefile.patch	2021-08-02 15:05:31.000000000 +0800
+@@ -24,7 +24,7 @@
+ # 3. Removed -Werror: Not block compilation for non-vital warnings, especially when the
+ #    code is tested on newer systems. If the code is used in production, add -Werror back
+ CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DNDEBUG -DBRPC_REVISION=\"$(shell ./tools/get_brpc_revision.sh .)\"
+-CXXFLAGS=$(CPPFLAGS) -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -std=c++0x
++CXXFLAGS=$(CPPFLAGS) -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -fno-gcse -std=c++0x
+ CFLAGS=$(CPPFLAGS) -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-unused-parameter -fno-omit-frame-pointer
+ DEBUG_CXXFLAGS = $(filter-out -DNDEBUG,$(CXXFLAGS)) -DUNIT_TEST -DBVAR_NOT_LINK_DEFAULT_VARIABLES
+ DEBUG_CFLAGS = $(filter-out -DNDEBUG,$(CFLAGS)) -DUNIT_TEST
+@@ -41,7 +41,7 @@
+ 
+ #required by butil/crc32.cc to boost performance for 10x
+ ifeq ($(shell test $(GCC_VERSION) -ge 40400; echo $$?),0)
+-	CXXFLAGS+=-msse4 -msse4.2
++	# CXXFLAGS+=-msse4 -msse4.2
+ endif
+ #not solved yet
+ ifeq ($(CC),gcc)

--- a/setup_cmake.sh
+++ b/setup_cmake.sh
@@ -14,7 +14,6 @@ else
     exit 1
 fi
 
-
 curl -SLo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-"$ARCH".tar.gz
 tar xzf cmake.tar.gz -C /usr/local/ --strip-components=1
 rm -rf cmake.tar.gz

--- a/setup_cmake.sh
+++ b/setup_cmake.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# File   : setup_cmake.sh
+
+set -eE
+
+INPUT=${1:-$(arch)}
+
+if [[ $INPUT = 'i386' || $INPUT = 'x86_64' || $INPUT = 'amd64' ]]; then
+    ARCH=x86_64
+elif [[ $INPUT = 'aarch64' ]]; then
+    ARCH=aarch64
+fi
+
+
+curl -SLo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-"$ARCH".tar.gz
+tar xzf cmake.tar.gz -C /usr/local/ --strip-components=1
+rm -rf cmake.tar.gz

--- a/setup_cmake.sh
+++ b/setup_cmake.sh
@@ -7,8 +7,11 @@ INPUT=${1:-$(arch)}
 
 if [[ $INPUT = 'i386' || $INPUT = 'x86_64' || $INPUT = 'amd64' ]]; then
     ARCH=x86_64
-elif [[ $INPUT = 'aarch64' ]]; then
+elif [[ $INPUT = 'aarch64' || $INPUT = 'arm64' ]]; then
     ARCH=aarch64
+else
+    echo "Unsupported arch: $INPUT"
+    exit 1
 fi
 
 

--- a/var.sh
+++ b/var.sh
@@ -15,3 +15,5 @@ target_arch() {
     # if ARCH environment variable is not provided, use the host architecture
     echo "${ARCH:-$(arch)}"
 }
+_MAKEOPTS="-j$(nproc)"
+MAKEOPTS=${MAKEOPTS:-$_MAKEOPTS}

--- a/var.sh
+++ b/var.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-function os_type() {
-    if [[ "${OSTYPE}" == "darwin"* ]]; then
-	    echo "Mac"
+os_type() {
+    if [[ "$OSTYPE" = "darwin"* ]]; then
+        echo "darwin"
     else
-	    echo "Linux"
+        echo "$OSTYPE"
     fi
 }

--- a/var.sh
+++ b/var.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
 os_type() {
-    if [[ "$OSTYPE" = "darwin"* ]]; then
+    # use the OS environment variable, then bash env OSTYPE
+    if [[ -n "$OS" ]]; then
+        echo "$OS"
+    elif [[ "$OSTYPE" = "darwin"* ]]; then
         echo "darwin"
     else
         echo "$OSTYPE"
     fi
+}
+
+target_arch() {
+    # if ARCH environment variable is not provided, use the host architecture
+    echo "${ARCH:-$(arch)}"
 }


### PR DESCRIPTION
- various improvements 😹 
  - refactor `pack_all`
  - setup multi-arch hybridsql base docker image: for amd64 & arm64
- #12
  - libunwind: 1.1 upgrade to 1.5
  - openssl
     - `no-afalgeng` build flag
     - upgrade to 1.1.1k
  - absl:  upgrade to latest git commit to support arm64 build
  - brpc: 
    - rm `mss4` & `msse4.2`
    - add `-fno-gcse` flag

Anyway, arm64 build has not ported to github workflow yet, because centos7 do not have aarch64 cross compile version for `devtoolset08`, and GitHub do not support running arm64 docker image. Should figure out if it is ok to build it on another base image.